### PR TITLE
Separate different upstream programs

### DIFF
--- a/config/nginx.conf
+++ b/config/nginx.conf
@@ -7,40 +7,59 @@ server {
   ssl_certificate_key /etc/letsencrypt/live/cardchain.crowdcontrol.network/privkey.pem;
 
   # Improve HTTPS performance with session resumption
-	ssl_session_cache shared:SSL:10m;
-	ssl_session_timeout 10m;
+  ssl_session_cache shared:SSL:10m;
+  ssl_session_timeout 10m;
 
-	# Enable server-side protection against BEAST attacks
-	ssl_protocols TLSv1.2;
-	ssl_prefer_server_ciphers on;
-	ssl_ciphers "ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA384";
+  # Enable server-side protection against BEAST attacks
+  ssl_protocols TLSv1.2;
+  ssl_prefer_server_ciphers on;
+  ssl_ciphers "ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA384";
 
   # RFC-7919 recommended: https://wiki.mozilla.org/Security/Server_Side_TLS#ffdhe4096
   ssl_dhparam /etc/nginx/ssl/dhparam-4096.pem;
   ssl_ecdh_curve secp521r1:secp384r1;
 
-	# Aditional Security Headers
-	# ref: https://developer.mozilla.org/en-US/docs/Security/HTTP_Strict_Transport_Security
-	add_header Strict-Transport-Security "max-age=31536000; includeSubDomains";
+  # Aditional Security Headers
+  # ref: https://developer.mozilla.org/en-US/docs/Security/HTTP_Strict_Transport_Security
+  add_header Strict-Transport-Security "max-age=31536000; includeSubDomains";
 
-	# ref: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Frame-Options
-	add_header X-Frame-Options DENY always;
+  # ref: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Frame-Options
+  add_header X-Frame-Options DENY always;
 
-	# ref: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Content-Type-Options
-	add_header X-Content-Type-Options nosniff always;
+  # ref: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Content-Type-Options
+  add_header X-Content-Type-Options nosniff always;
 
-	# ref: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-XSS-Protection
-	add_header X-Xss-Protection "1; mode=block" always;
+  # ref: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-XSS-Protection
+  add_header X-Xss-Protection "1; mode=block" always;
 
   # Enable OCSP stapling
-	# ref. http://blog.mozilla.org/security/2013/07/29/ocsp-stapling-in-firefox
-	ssl_stapling on;
-	ssl_stapling_verify on;
-	ssl_trusted_certificate /etc/letsencrypt/live/cardchain.crowdcontrol.network/fullchain.pem;
-	resolver 1.1.1.1 1.0.0.1 [2606:4700:4700::1111] [2606:4700:4700::1001] valid=300s; # Cloudflare
-	resolver_timeout 5s;
+  # ref. http://blog.mozilla.org/security/2013/07/29/ocsp-stapling-in-firefox
+  ssl_stapling on;
+  ssl_stapling_verify on;
+  ssl_trusted_certificate /etc/letsencrypt/live/cardchain.crowdcontrol.network/fullchain.pem;
+  resolver 1.1.1.1 1.0.0.1 [2606:4700:4700::1111] [2606:4700:4700::1001] valid=300s; # Cloudflare
+  resolver_timeout 5s;
 
-  location / {
+  location ~ ^/cosmos/?((?<=/).*)?$ {
+    # Not sending ACAO header because it is already being added by the upstream
+    # add_header 'Access-Control-Allow-Origin' '*' always;
+    add_header 'Access-Control-Allow-Credentials' 'true' always;
+    add_header 'Access-Control-Allow-Headers' '*' always;
+    add_header 'Access-Control-Allow-Methods' '*' always;
+    add_header 'Access-Control-Max-Age' 1728000 always;
+
+    if ($request_method = 'OPTIONS') {
+      return 200;
+    }
+
+    proxy_redirect off;
+    proxy_set_header host $host;
+    proxy_set_header X-real-ip $remote_addr;
+    proxy_set_header X-forward-for $proxy_add_x_forwarded_for;
+    proxy_pass http://blockchain:1318/$1$is_args$args;
+  }
+
+  location ~ ^/tendermint/?((?<=/).*)?$ {
     add_header 'Access-Control-Allow-Origin' '*' always;
     add_header 'Access-Control-Allow-Credentials' 'true' always;
     add_header 'Access-Control-Allow-Headers' '*' always;
@@ -55,6 +74,24 @@ server {
     proxy_set_header host $host;
     proxy_set_header X-real-ip $remote_addr;
     proxy_set_header X-forward-for $proxy_add_x_forwarded_for;
-    proxy_pass http://blockchain:1318;
+    proxy_pass http://blockchain:26659/$1$is_args$args;
+  }
+  
+  location ~ ^/faucet/?((?<=/).*)?$ {
+    add_header 'Access-Control-Allow-Origin' '*' always;
+    add_header 'Access-Control-Allow-Credentials' 'true' always;
+    add_header 'Access-Control-Allow-Headers' '*' always;
+    add_header 'Access-Control-Allow-Methods' '*' always;
+    add_header 'Access-Control-Max-Age' 1728000 always;
+
+    if ($request_method = 'OPTIONS') {
+      return 200;
+    }
+
+    proxy_redirect off;
+    proxy_set_header host $host;
+    proxy_set_header X-real-ip $remote_addr;
+    proxy_set_header X-forward-for $proxy_add_x_forwarded_for;
+    proxy_pass http://blockchain:4500/$1$is_args$args;
   }
 }


### PR DESCRIPTION
This PR separates the different programs `faucet`, `cosmos-api`, and `tendermint-api` into different endpoints and tries to proxy-pass requests to the correct program on a path-based manner.

This PR does also replace tabs with spaces for the sake of consistency.